### PR TITLE
Share Shopping List via WhatsApp

### DIFF
--- a/frontend/src/components/Main/Main.css
+++ b/frontend/src/components/Main/Main.css
@@ -5,6 +5,10 @@ form article:last-of-type {
 .download {
   max-width: var(--breakpoint);
 
+  display: flex;
+  flex-direction: column;
+
+  gap: var(--pico-spacing);
   position: sticky;
   bottom: 0;
 
@@ -15,5 +19,26 @@ form article:last-of-type {
 
   & button {
     margin-bottom: 0 !important;
+  }
+
+  & .whatsapp-button {
+    background-color: #25d366;
+    color: white;
+    --pico-border-color: #25d366;
+  }
+  & .whatsapp-button:hover {
+    --pico-border-color: #1ebe57;
+  }
+
+  & .whatsapp-button:focus {
+    transition: box-shadow 0.2s ease, background-color 0.2s ease;
+    background-color: #1ebe57;
+    --pico-border-color: #25d366;
+    outline: none; /* Remove default focus outline */
+    --pico-box-shadow: var(
+        --pico-button-hover-box-shadow,
+        0 0 0 rgba(0, 0, 0, 0)
+      ),
+      0 0 0 var(--pico-outline-width) #25d366;
   }
 }

--- a/frontend/src/components/Main/Main.css
+++ b/frontend/src/components/Main/Main.css
@@ -20,25 +20,7 @@ form article:last-of-type {
   & button {
     margin-bottom: 0 !important;
   }
-
-  & .whatsapp-button {
-    background-color: #25d366;
-    color: white;
-    --pico-border-color: #25d366;
-  }
-  & .whatsapp-button:hover {
-    --pico-border-color: #1ebe57;
-  }
-
-  & .whatsapp-button:focus {
-    transition: box-shadow 0.2s ease, background-color 0.2s ease;
-    background-color: #1ebe57;
-    --pico-border-color: #25d366;
-    outline: none; /* Remove default focus outline */
-    --pico-box-shadow: var(
-        --pico-button-hover-box-shadow,
-        0 0 0 rgba(0, 0, 0, 0)
-      ),
-      0 0 0 var(--pico-outline-width) #25d366;
-  }
+}
+.whatsAppButton {
+  background-color: var(--pico-primary) !important;
 }

--- a/frontend/src/components/Main/Main.jsx
+++ b/frontend/src/components/Main/Main.jsx
@@ -108,7 +108,7 @@ const Main = () => {
           <button type="submit">Download</button>
           <button
             type="button"
-            className="whatsapp-button"
+            className="whatsAppButton"
             onClick={handleWhatsAppShare}
           >
             Share via WhatsApp

--- a/frontend/src/components/Main/Main.jsx
+++ b/frontend/src/components/Main/Main.jsx
@@ -5,6 +5,7 @@ import { useTitle } from "@/hooks/useTitle";
 import { Downloader } from "@/utils/Downloader";
 import itemsData from "@/data/items.json";
 import "@/components/Main/Main.css";
+import { generateWhatsAppLink } from "@/utils/WhatsAppLinkGenerator";
 
 // `localStorage` key for saved items.
 const SELECTED_ITEMS = "selectedItems";
@@ -32,7 +33,7 @@ const Main = () => {
    */
   const handleItemChange = (event) => {
     const { name, checked } = event.target;
-    
+
     let updatedSelectedItems;
 
     if (checked) {
@@ -70,6 +71,13 @@ const Main = () => {
     button.setAttribute("aria-busy", "false");
   };
 
+  const handleWhatsAppShare = () => {
+    const link = generateWhatsAppLink(selectedItems);
+    if (link) {
+      window.open(link, "_blank");
+    }
+  };
+
   return (
     <>
       <ColorSchemeSwitcher />
@@ -98,6 +106,13 @@ const Main = () => {
 
         <div className="download">
           <button type="submit">Download</button>
+          <button
+            type="button"
+            className="whatsapp-button"
+            onClick={handleWhatsAppShare}
+          >
+            Share via WhatsApp
+          </button>
         </div>
       </form>
     </>

--- a/frontend/src/utils/WhatsAppLinkGenerator.js
+++ b/frontend/src/utils/WhatsAppLinkGenerator.js
@@ -1,0 +1,16 @@
+/**
+ * Generates a WhatsApp link with a pre-filled message containing the selected items.
+ *
+ * @param {Array<string>} items - The list of selected items.
+ * @returns {string} - The WhatsApp share link.
+ */
+export const generateWhatsAppLink = (items) => {
+  if (items.length === 0) {
+    alert("Please select at least one item.");
+    return "";
+  }
+
+  const message = `Here is my shopping list:\n\n${items.join("\n")}`;
+  const encodedMessage = encodeURIComponent(message);
+  return `https://wa.me/?text=${encodedMessage}`;
+};


### PR DESCRIPTION
Added functionality to share via whatsapp, some custom css to the whatsapp button.

Suggested changes: 

Add whatsapp icon instead (fontawesome?) and make the buttons appear next to eachother to make the UI more streamlined and have the buttons take up less space. 

Further improvement: Create a whatsapp button component and move the logic and css to that component to keep it cleaner. 

